### PR TITLE
feature: remove cancelled registries

### DIFF
--- a/src/data/get_data.py
+++ b/src/data/get_data.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 from st_files_connection import FilesConnection
 from data.etl import AirtableDataExtractor, DataMapper
+from data.updates import update_data
 
 THRESHOLD_DATE = "2024-06-03"
 
@@ -22,6 +23,18 @@ def get_gcs_data(file_path: str) -> DataMapper:
     return DataMapper(data=data)
 
 
+def get_updates_data() -> DataMapper:
+    """Get the data of updates"""
+    updates_data = get_data(
+        base_id=st.secrets.airtable.base_id,
+        table_name=st.secrets.airtable.updates_table,
+    ).data
+    col_name = "Eliminado de Streamlit"
+    mask = (updates_data[col_name].isna()) | (updates_data[col_name] == False)
+    subset_data = updates_data[mask]
+    return DataMapper(data=subset_data)
+
+
 @st.cache_data(ttl=15 * 60)
 def get_registries() -> DataMapper:
     airtable_data = get_data(
@@ -31,6 +44,8 @@ def get_registries() -> DataMapper:
     gcs_data = get_gcs_data(file_path="youth_camp_registries/new_backup_raw_data_snapshot.parquet")
     data = pd.concat([airtable_data.data, gcs_data.data])
     data = data.drop_duplicates(subset=["Tipo de Documento", "Número de Documento", "Created"])
+    data_to_change = get_updates_data().data
+    data = update_data(registries_data=data, updates_data=data_to_change)
     return DataMapper(data=data)
 
 

--- a/src/data/get_data.py
+++ b/src/data/get_data.py
@@ -23,7 +23,7 @@ def get_gcs_data(file_path: str) -> DataMapper:
     return DataMapper(data=data)
 
 
-def get_updates_data() -> DataMapper:
+def get_updates_data() -> pd.DataFrame:
     """Get the data of updates"""
     updates_data = get_data(
         base_id=st.secrets.airtable.base_id,
@@ -32,7 +32,7 @@ def get_updates_data() -> DataMapper:
     col_name = "Eliminado de Streamlit"
     mask = (updates_data[col_name].isna()) | (updates_data[col_name] == False)
     subset_data = updates_data[mask]
-    return DataMapper(data=subset_data)
+    return subset_data
 
 
 @st.cache_data(ttl=15 * 60)
@@ -44,7 +44,7 @@ def get_registries() -> DataMapper:
     gcs_data = get_gcs_data(file_path="youth_camp_registries/new_backup_raw_data_snapshot.parquet")
     data = pd.concat([airtable_data.data, gcs_data.data])
     data = data.drop_duplicates(subset=["Tipo de Documento", "Número de Documento", "Created"])
-    data_to_change = get_updates_data().data
+    data_to_change = get_updates_data()
     data = update_data(registries_data=data, updates_data=data_to_change)
     return DataMapper(data=data)
 

--- a/src/data/updates.py
+++ b/src/data/updates.py
@@ -57,6 +57,7 @@ def update_data(registries_data: pd.DataFrame, updates_data: pd.DataFrame) -> pd
         The updated data
     """
     # Delete the ids from the dataset
+    # TODO: add the logic of money transfer to other people
     ids_to_delete = get_ids_to_delete(data=updates_data)
     final_data = delete_records(data=registries_data, ids=ids_to_delete)
 

--- a/src/data/updates.py
+++ b/src/data/updates.py
@@ -1,0 +1,63 @@
+import pandas as pd
+
+
+def get_ids_to_delete(data: pd.DataFrame) -> list[int]:
+    """
+    Get the list of ids to delete
+
+    Parameters
+    ----------
+    data: pd.DataFrame
+        The data both from GCS and Airtable
+
+    Returns
+    -------
+    list[int]
+        The list of ids to delete
+    """
+    mask = data["Tipo de devolución"].isin(["Consignación", "Retiro de niños"])
+    ids_to_delete = data.loc[mask, "Número de Documento"].drop_duplicates()
+    return ids_to_delete.tolist()
+
+
+def delete_records(data: pd.DataFrame, ids: list[int]) -> pd.DataFrame:
+    """
+    Delete the records of people that cannot go to the camp
+
+    Parameters
+    ----------
+    data: pd.DataFrame
+        The final dataset
+    ids: list[int]
+        The list of ids to delete
+
+    Returns
+    -------
+    pd.DataFrame
+        The final dataset without the records to delete
+    """
+    mask = data["Número de Documento"].isin(ids)
+    return data[~mask]
+
+
+def update_data(registries_data: pd.DataFrame, updates_data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Execute the different updates in the registries data
+
+    Parameters
+    ----------
+    registries_data: pd.DataFrame
+        The data from GCS and Airtable that contains the registries information
+    updates_data: pd.DataFrame
+        The data that contains the required updates to perform
+
+    Returns
+    -------
+    pd.DataFrame
+        The updated data
+    """
+    # Delete the ids from the dataset
+    ids_to_delete = get_ids_to_delete(data=updates_data)
+    final_data = delete_records(data=registries_data, ids=ids_to_delete)
+
+    return final_data


### PR DESCRIPTION
# Remove cancelled registries

This PR addresses the removal of unnecessary registries, due to the following causes:

- The person can no longer attend to the camp
- The person went to the kids camp instead of the youth camp