### PR TITLE
feature: move registries

### DIFF
--- a/src/data/get_data.py
+++ b/src/data/get_data.py
@@ -29,10 +29,7 @@ def get_updates_data() -> pd.DataFrame:
         base_id=st.secrets.airtable.base_id,
         table_name=st.secrets.airtable.updates_table,
     ).data
-    col_name = "Eliminado de Streamlit"
-    mask = (updates_data[col_name].isna()) | (updates_data[col_name] == False)
-    subset_data = updates_data[mask]
-    return subset_data
+    return updates_data
 
 
 @st.cache_data(ttl=15 * 60)


### PR DESCRIPTION
This PR addresses the issue of moving registries to another attendants. As a caveat, it is a manual process for the moment; if more registries need to be moved, we'll need to add them manually to the dict `IDS_TO_OVERRIDE`.